### PR TITLE
Add handling for CA tlds while updating contact info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## Dev
+* Add special handling in contact update for CA domains
+
 ## 1.0.1
 * Added more auto-renewed TLDs (.at and .fr) ([#9][9])
 

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -288,6 +288,12 @@ class OpenSRS(object):
                 'tech': contact,
             },
         }
+
+        if domain.lower().endswith('.ca'):
+            # CA domains fail to update if billing contact info is set, remove
+            # to handle these cases
+            del attributes['contact_set']['billing']
+
         return self._req(action='MODIFY', object='DOMAIN', cookie=cookie,
                          attributes=attributes)
 

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -289,7 +289,7 @@ class OpenSRS(object):
             },
         }
 
-        if domain.lower().endswith('.ca'):
+        if domain.endswith('.ca'):
             # CA domains fail to update if billing contact info is set, remove
             # to handle these cases
             del attributes['contact_set']['billing']


### PR DESCRIPTION
CA tlds reject contact types of `billing`, causing failure to update

re: https://github.com/yola/production/issues/3137