### PR TITLE
Add support for immediately processing orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## Dev
+* Add `order_processing_method` method to `register_domain` method
+
 ## 2.1.0
 * Add `OpenSRS.list_domains()`
 * Add `Domain.to_dict()`

--- a/opensrs/constants.py
+++ b/opensrs/constants.py
@@ -1,1 +1,12 @@
 AUTO_RENEWED_TLDS = ('de', 'dk', 'za', 'at', 'fr')
+
+
+class OrderProcessingMethod(object):
+    """Indicates how to process the order.
+
+    process: Proceed with the order immediately.
+    save: Pend the order for later approval by the RSP.
+
+    """
+    PROCESS = 'process'
+    SAVE = 'save'

--- a/opensrs/constants.py
+++ b/opensrs/constants.py
@@ -1,7 +1,7 @@
 AUTO_RENEWED_TLDS = ('de', 'dk', 'za', 'at', 'fr')
 
 
-class OrderProcessingMethod(object):
+class OrderProcessingMethods(object):
     """Indicates how to process the order.
 
     process: Proceed with the order immediately.

--- a/opensrs/errors.py
+++ b/opensrs/errors.py
@@ -73,3 +73,7 @@ class DomainAlreadyRenewed(BadResponseError):
 
 class DomainLookupUnavailable(OperationFailure):
     pass
+
+
+class DomainRegistrationTimedOut(BadResponseError):
+    pass

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -103,6 +103,8 @@ class OpenSRS(object):
     def _make_common_reg_attrs(self, domain, user, username, password,
                                reg_domain, **kw):
         contact = self.make_contact(user, domain, **kw)
+        order_processing_method = kw.get(
+            'order_processing_method', OrderProcessingMethod.SAVE)
         # .eu domains require GB instead of UK as the country code
         if domain.lower().endswith('.eu') and contact['country'] == 'UK':
             contact['country'] = 'GB'
@@ -384,11 +386,13 @@ class OpenSRS(object):
 
     def register_domain(self, domain, purchase_period, user, user_id,
                         password, nameservers=None, private_reg=False,
-                        reg_domain=None, extras=None):
+                        reg_domain=None, extras=None,
+                        order_processing_method=OrderProcessingMethod.SAVE):
         extras = extras or {}
-        attrs = self._make_domain_reg_attrs(domain, purchase_period, user,
-                                            user_id, password, nameservers,
-                                            private_reg, reg_domain, **extras)
+        attrs = self._make_domain_reg_attrs(
+            domain, purchase_period, user, user_id, password, nameservers,
+            private_reg, reg_domain,
+            order_processing_method=order_processing_method, **extras)
         if extras:
             attrs.update(extras)
         try:

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -4,7 +4,7 @@ import logging
 from demands.pagination import PaginatedResults, RESULTS_KEY
 
 from opensrs import errors
-from opensrs.constants import AUTO_RENEWED_TLDS, OrderProcessingMethod
+from opensrs.constants import AUTO_RENEWED_TLDS, OrderProcessingMethods
 from opensrs.xcp import XCPMessage, XCPChannel
 
 
@@ -104,7 +104,7 @@ class OpenSRS(object):
                                reg_domain, **kw):
         contact = self.make_contact(user, domain, **kw)
         order_processing_method = kw.get(
-            'order_processing_method', OrderProcessingMethod.SAVE)
+            'order_processing_method', OrderProcessingMethods.SAVE)
         # .eu domains require GB instead of UK as the country code
         if domain.lower().endswith('.eu') and contact['country'] == 'UK':
             contact['country'] = 'GB'
@@ -387,7 +387,7 @@ class OpenSRS(object):
     def register_domain(self, domain, purchase_period, user, user_id,
                         password, nameservers=None, private_reg=False,
                         reg_domain=None, extras=None,
-                        order_processing_method=OrderProcessingMethod.SAVE):
+                        order_processing_method=OrderProcessingMethods.SAVE):
         extras = extras or {}
         attrs = self._make_domain_reg_attrs(
             domain, purchase_period, user, user_id, password, nameservers,

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -4,7 +4,7 @@ import logging
 from demands.pagination import PaginatedResults, RESULTS_KEY
 
 from opensrs import errors
-from opensrs.constants import AUTO_RENEWED_TLDS
+from opensrs.constants import AUTO_RENEWED_TLDS, OrderProcessingMethod
 from opensrs.xcp import XCPMessage, XCPChannel
 
 
@@ -118,7 +118,7 @@ class OpenSRS(object):
             'reg_password': password,
             'reg_type': 'new',
             'f_lock_domain': '1',
-            'handle': 'save',
+            'handle': OrderProcessingMethod.SAVE,
         }
         if reg_domain is not None:
             attributes['reg_domain'] = reg_domain

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -122,7 +122,7 @@ class OpenSRS(object):
             'reg_password': password,
             'reg_type': 'new',
             'f_lock_domain': '1',
-            'handle': OrderProcessingMethod.SAVE,
+            'handle': order_processing_method,
         }
         if reg_domain is not None:
             attributes['reg_domain'] = reg_domain

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -48,6 +48,8 @@ class OpenSRS(object):
     CODE_CANNOT_REDEEM_DOMAIN = '400'
     CODE_CANNOT_PUSH_DOMAIN = '465'
 
+    CODE_CLIENT_TIMED_OUT = '705'
+
     MSG_ALREADY_RENEWED_SANDBOX = 'Domain Already Renewed'
 
     def __init__(self, host, port, username, private_key, default_timeout):
@@ -405,6 +407,8 @@ class OpenSRS(object):
                             'Invalid syntax on domain')):
                     raise errors.InvalidDomain(e)
                 raise errors.DomainRegistrationFailure(e)
+            if e.response_code == self.CODE_CLIENT_TIMED_OUT:
+                raise errors.DomainRegistrationTimedOut(e)
             raise
 
     def process_pending(self, order_id, cancel=False):

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -335,6 +335,25 @@ class OpenSRSTest(TestCase):
         except errors.DomainTaken:
             pass
 
+    def test_register_fail_timed_out(self):
+        response_data = {
+            'response_text': 'Timed out, resubmit request.',
+            'protocol': 'XCP',
+            'response_code': '705',
+            'object': 'DOMAIN',
+            'action': 'REPLY',
+            'attributes': {},
+            'is_success': '0'
+        }
+        opensrs = self.safe_opensrs(
+            self._data_domain_reg('foo.com', '1', 'foo', 'bar'), response_data)
+        try:
+            opensrs.register_domain(
+                'foo.com', 1, self._objdata_user_contact(), 'foo', 'bar')
+            self.fail('Expected DomainRegistrationTimedOut exception.')
+        except errors.DomainRegistrationTimedOut:
+            pass
+
     def test_register_succeed(self):
         response_data = {
             'response_text': 'Registration successful',

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from mock import Mock, patch
 
 from opensrs import opensrsapi, xcp, errors
-from opensrs.constants import OrderProcessingMethod
+from opensrs.constants import OrderProcessingMethods
 from test_settings import CONNECTION_OPTIONS
 
 
@@ -206,7 +206,7 @@ class OpenSRSTest(TestCase):
             'f_lock_domain': '1',
             'f_whois_privacy': '0',
             'reg_type': 'new',
-            'handle': OrderProcessingMethod.SAVE})
+            'handle': OrderProcessingMethods.SAVE})
 
     def _data_process_pending(self, order_id, cancel):
         attributes = {'order_id': order_id}
@@ -231,7 +231,7 @@ class OpenSRSTest(TestCase):
             'f_lock_domain': '1',
             'f_whois_privacy': '0',
             'reg_type': 'new',
-            'handle': OrderProcessingMethod.SAVE,
+            'handle': OrderProcessingMethods.SAVE,
             'nameserver_list': [
                 {'name': 'ns1.example.com', 'sortorder': '1'},
                 {'name': 'ns2.example.com', 'sortorder': '2'}]})

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from mock import Mock, patch
 
 from opensrs import opensrsapi, xcp, errors
+from opensrs.constants import OrderProcessingMethod
 from test_settings import CONNECTION_OPTIONS
 
 
@@ -205,7 +206,7 @@ class OpenSRSTest(TestCase):
             'f_lock_domain': '1',
             'f_whois_privacy': '0',
             'reg_type': 'new',
-            'handle': 'save'})
+            'handle': OrderProcessingMethod.SAVE})
 
     def _data_process_pending(self, order_id, cancel):
         attributes = {'order_id': order_id}
@@ -230,7 +231,7 @@ class OpenSRSTest(TestCase):
             'f_lock_domain': '1',
             'f_whois_privacy': '0',
             'reg_type': 'new',
-            'handle': 'save',
+            'handle': OrderProcessingMethod.SAVE,
             'nameserver_list': [
                 {'name': 'ns1.example.com', 'sortorder': '1'},
                 {'name': 'ns2.example.com', 'sortorder': '2'}]})


### PR DESCRIPTION
Needed for domainservice work in https://github.com/yola/domainservice/issues/340

OpenSRS has 2 ways of processing orders: `save` and `process`.
`save` creates the order but requires an additional call to `process_pending` to actually process the roder.
`process` creates the order and processing it immediately.

Adding a `order_processing_method` parameter to `register_domain` will allow a client to specify which order processing method to use.