### PR TITLE
bump version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
-## Dev
+## 2.2.0
 * Add `order_processing_method` method to `register_domain` method
 
 ## 2.1.0

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS


### PR DESCRIPTION
Version 2.2.0 adds the new order_processing_method param to the register_domain method.

https://github.com/yola/opensrs/pull/22