### PR TITLE
Add methods for explicitly creating pending orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Dev
 * Add `create_pending_domain_registration` method
-* Update `register_domain` to immediately process the order
+* Add `create_pending_domain_renewal` method
+* Add `create_pending_domain_transfer` method
+* Change `register_domain` to immediately process the order
+* Change `transfer_domain` to immediately process the order
+* Change `renew_domain` to immediately process the order
 
 ## 2.2.0
 * Add `order_processing_method` parameter to `register_domain` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
 ## Dev
+* Add `create_pending_domain_registration` method
 * Update `register_domain` to immediately process the order
 
 ## 2.2.0
-* Add `order_processing_method` method to `register_domain` method
+* Add `order_processing_method` parameter to `register_domain` method
 
 ## 2.1.0
 * Add `OpenSRS.list_domains()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## Dev
+* Update `register_domain` to immediately process the order
+
 ## 2.2.0
 * Add `order_processing_method` method to `register_domain` method
 

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -417,6 +417,15 @@ class OpenSRS(object):
             domains['search_key'] = data['search_key']
         return domains
 
+    def create_pending_domain_registration(
+            self, domain, purchase_period, user, user_id,
+            password, nameservers=None, private_reg=False,
+            reg_domain=None, extras=None):
+        return self._register_domain(
+            domain, purchase_period, user, user_id, password,
+            nameservers=nameservers, private_reg=private_reg,
+            reg_domain=reg_domain, extras=extras)
+
     def register_domain(self, domain, purchase_period, user, user_id,
                         password, nameservers=None, private_reg=False,
                         reg_domain=None, extras=None):

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -295,10 +295,11 @@ class OpenSRS(object):
         return rsp.get_data()['attributes']['order_id']
 
     def _transfer_domain(self, domain, user, user_id, password,
-                         nameservers=None, reg_domain=None, extras=None):
+                         nameservers=None, reg_domain=None, extras=None,
+                         order_processing_method=OrderProcessingMethods.SAVE):
         attrs = self._make_domain_transfer_attrs(
             domain, user, user_id, password, nameservers, reg_domain,
-            order_processing_method=OrderProcessingMethods.SAVE)
+            order_processing_method=order_processing_method)
         if extras:
             attrs.update(extras)
 
@@ -580,7 +581,8 @@ class OpenSRS(object):
                         nameservers=None, reg_domain=None, extras=None):
         return self._transfer_domain(
             domain, user, user_id, password, nameservers=nameservers,
-            reg_domain=reg_domain, extras=extras)
+            reg_domain=reg_domain, extras=extras,
+            order_processing_method=OrderProcessingMethods.PROCESS)
 
     def list_transfers(self, transfer_id=None, start_date=None, end_date=None):
         rsp = self._get_transfers_in(transfer_id=transfer_id,

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -479,6 +479,10 @@ class OpenSRS(object):
         self._set_domain_whois_privacy(cookie, enable_privacy)
         return True
 
+    def create_pending_domain_renewal(self, domain, current_expiration_year,
+                                      period):
+        return self._renew_domain(domain, current_expiration_year, period)
+
     def renew_domain(self, domain, current_expiration_year, period):
         return self._renew_domain(
             domain, current_expiration_year, period,

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -577,6 +577,13 @@ class OpenSRS(object):
                 }
         return domain_data
 
+    def create_pending_domain_transfer(self, domain, user, user_id, password,
+                                       nameservers=None, reg_domain=None,
+                                       extras=None):
+        return self._transfer_domain(
+            domain, user, user_id, password, nameservers=nameservers,
+            reg_domain=reg_domain, extras=extras)
+
     def transfer_domain(self, domain, user, user_id, password,
                         nameservers=None, reg_domain=None, extras=None):
         return self._transfer_domain(

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -4,6 +4,7 @@ from mock import Mock, patch
 
 from opensrs import opensrsapi, xcp, errors
 from opensrs.constants import OrderProcessingMethods
+from opensrs.opensrsapi import OpenSRS, is_auto_renewed
 from test_settings import CONNECTION_OPTIONS
 
 
@@ -458,14 +459,6 @@ class OpenSRSTest(TestCase):
         self.assertEquals(expected, opensrs.create_pending_domain_registration(
             'foo.com', 1, self._objdata_user_contact(), 'foo', 'bar'))
 
-    def test_is_auto_renewed(self):
-        osrs = opensrsapi.OpenSRS('host', 'port', 'user', 'key', 'timeout')
-        error = Mock(response_code=osrs.CODE_RENEWAL_IS_NOT_ALLOWED)
-
-        self.assertTrue(osrs._is_auto_renewed(error, 'foo.co.za'))
-        self.assertTrue(osrs._is_auto_renewed(error, 'bar.de'))
-        self.assertFalse(osrs._is_auto_renewed(error, 'test.com'))
-
     def test_renew_domain_fails_when_already_renewed(self):
         opensrs = self.safe_opensrs(
             self._xcp_data('RENEW', 'DOMAIN', {
@@ -617,6 +610,15 @@ class OpenSRSTest(TestCase):
             expected,
             opensrs.create_pending_domain_transfer(
                 'foo.com', self._objdata_user_contact(), 'foo', 'bar'))
+
+
+class IsAutoRenewedTestCase(TestCase):
+    def test_is_auto_renewed(self):
+        error = Mock(response_code=OpenSRS.CODE_RENEWAL_IS_NOT_ALLOWED)
+
+        self.assertTrue(is_auto_renewed(error, 'foo.co.za'))
+        self.assertTrue(is_auto_renewed(error, 'bar.de'))
+        self.assertFalse(is_auto_renewed(error, 'test.com'))
 
 
 class OpenSRSTestCase(TestCase):

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -397,6 +397,30 @@ class OpenSRSTest(TestCase):
             'foo.com', 1, self._objdata_user_contact(), 'foo', 'bar',
             nameservers=nameservers))
 
+    def test_create_pending_domain_registration_succeeds(self):
+        response_data = {
+            'response_text': 'Registration successful',
+            'protocol': 'XCP',
+            'response_code': '200',
+            'object': 'DOMAIN',
+            'action': 'REPLY',
+            'attributes': {
+                'admin_email': 'email@example.com',
+                'id': '1065034'
+            },
+            'is_success': '1'}
+        opensrs = self.safe_opensrs(
+            self._data_domain_reg('foo.com', '1', 'foo', 'bar'),
+            response_data)
+        expected = {
+            'domain_name': 'foo.com',
+            'registrar_data': {
+                'ref_number': '1065034'
+            }
+        }
+        self.assertEquals(expected, opensrs.create_pending_domain_registration(
+            'foo.com', 1, self._objdata_user_contact(), 'foo', 'bar'))
+
     def test_is_auto_renewed(self):
         osrs = opensrsapi.OpenSRS('host', 'port', 'user', 'key', 'timeout')
         error = Mock(response_code=osrs.CODE_RENEWAL_IS_NOT_ALLOWED)

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -309,7 +309,9 @@ class OpenSRSTest(TestCase):
             'is_success': '0',
             'transaction_id': '2009-06-29 08:47:20 27585 101'}
         opensrs = self.safe_opensrs(
-            self._data_domain_reg('foo.com', '1', 'foo', 'bar'), response_data)
+            self._data_domain_reg('foo.com', '1', 'foo', 'bar',
+                                  handle=OrderProcessingMethods.PROCESS),
+            response_data)
         try:
             opensrs.register_domain('foo.com', 1, self._objdata_user_contact(),
                                     'foo', 'bar')
@@ -328,7 +330,9 @@ class OpenSRSTest(TestCase):
             'is_success': '0'
         }
         opensrs = self.safe_opensrs(
-            self._data_domain_reg('foo.com', '1', 'foo', 'bar'), response_data)
+            self._data_domain_reg('foo.com', '1', 'foo', 'bar',
+                                  handle=OrderProcessingMethods.PROCESS),
+            response_data)
         try:
             opensrs.register_domain(
                 'foo.com', 1, self._objdata_user_contact(), 'foo', 'bar')
@@ -348,24 +352,10 @@ class OpenSRSTest(TestCase):
                 'id': '1065034'
             },
             'is_success': '1'}
-        process_response = {
-            'response_text': ('Domain registration successfully completed\n'
-                              'Domain successfully locked.'),
-            'protocol': 'XCP',
-            'response_code': '200',
-            'object': 'DOMAIN',
-            'action': 'REPLY',
-            'attributes': {
-                'order_id': '1065034',
-                'lock_state': '1',
-                'id': '616784',
-                'f_auto_renew': 'N',
-                'registration expiration date': '2010-09-17 13:26:27'},
-            'is_success': '1'}
         opensrs = self.safe_opensrs(
-            self._data_domain_reg('foo.com', '1', 'foo', 'bar'), response_data)
-        self.mcf.add_req(
-            self._data_process_pending('1065034', False), process_response)
+            self._data_domain_reg('foo.com', '1', 'foo', 'bar',
+                                  handle=OrderProcessingMethods.PROCESS),
+            response_data)
         expected = {
             'domain_name': 'foo.com',
             'registrar_data': {
@@ -387,31 +377,16 @@ class OpenSRSTest(TestCase):
                 'id': '1065034'
             },
             'is_success': '1'}
-        process_response = {
-            'response_text': ('Domain registration successfully completed\n'
-                              'Domain successfully locked.'),
-            'protocol': 'XCP',
-            'response_code': '200',
-            'object': 'DOMAIN',
-            'action': 'REPLY',
-            'attributes': {
-                'order_id': '1065034',
-                'lock_state': '1',
-                'id': '616784',
-                'f_auto_renew': 'N',
-                'registration expiration date': '2010-09-17 13:26:27'},
-            'is_success': '1'}
         nameservers = ['ns1.example.com', 'ns2.example.com']
         opensrs = self.safe_opensrs(
             self._data_domain_reg(
                 'foo.com', '1', 'foo', 'bar', custom_nameservers='1',
+                handle=OrderProcessingMethods.PROCESS,
                 nameserver_list=[
                     {'name': 'ns1.example.com', 'sortorder': '1'},
                     {'name': 'ns2.example.com', 'sortorder': '2'}]
             ),
             response_data)
-        self.mcf.add_req(
-            self._data_process_pending('1065034', False), process_response)
         expected = {
             'domain_name': 'foo.com',
             'registrar_data': {


### PR DESCRIPTION
These new `create_pending_domain_ACTION` methods will keep the logic of determining which type of processing (immediate or pending) should be done on an order in the opensrs library.

