### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
-## Dev
+## 3.0.0
 * Add `create_pending_domain_registration` method
 * Add `create_pending_domain_renewal` method
 * Add `create_pending_domain_transfer` method

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '2.2.0'
+__version__ = '3.0.0'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS


### PR DESCRIPTION
This is a major version bump because the behavior of existing `register_domain`, `renew_domain`, and `transfer_domain` methods was changed in backwards incompatible ways.
Those methods now immediately process orders.  The new `create_pending_domain_*` methods can be used to create pending orders.