### PR TITLE
return transfer_id value from transfer requests for use in subsequent requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## Dev
+* Return `transfer_id` from `transfer_domain` and
+    `create_pending_domain_transfer`
+
 ## 3.0.0
 * Add `create_pending_domain_registration` method
 * Add `create_pending_domain_renewal` method

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -349,10 +349,15 @@ class OpenSRS(object):
             attrs.update(extras)
 
         rsp = self._sw_register_domain(attrs)
-        order_id = rsp.get_data()['attributes']['id']
+        response_attributes = rsp.get_data()['attributes']
+        order_id = response_attributes['id']
+        transfer_id = response_attributes['transfer_id']
         return {
             'domain_name': domain,
-            'registrar_data': {'ref_number': order_id},
+            'registrar_data': {
+                'ref_number': order_id,
+                'transfer_id': transfer_id
+            },
         }
 
     def _get_domains_contacts(self, domains):

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -586,11 +586,15 @@ class OpenSRSTest(TestCase):
             self._get_domain_transfer_request_data(
                 'foo.com', 'foo', 'bar',
                 handle=OrderProcessingMethods.PROCESS),
-            self._get_domain_transfer_response_data(attributes={'id': '123'})
+            self._get_domain_transfer_response_data(
+                attributes={'id': '123', 'transfer_id': '456'})
         )
         expected = {
             'domain_name': 'foo.com',
-            'registrar_data': {'ref_number': '123'}
+            'registrar_data': {
+                'ref_number': '123',
+                'transfer_id': '456'
+            }
         }
         self.assertEqual(
             expected,
@@ -600,11 +604,15 @@ class OpenSRSTest(TestCase):
     def test_create_pending_domain_transfer_succeeds(self):
         opensrs = self.safe_opensrs(
             self._get_domain_transfer_request_data('foo.com', 'foo', 'bar'),
-            self._get_domain_transfer_response_data(attributes={'id': '123'})
+            self._get_domain_transfer_response_data(
+                attributes={'id': '123', 'transfer_id': '456'})
         )
         expected = {
             'domain_name': 'foo.com',
-            'registrar_data': {'ref_number': '123'}
+            'registrar_data': {
+                'ref_number': '123',
+                'transfer_id': '456'
+            }
         }
         self.assertEqual(
             expected,


### PR DESCRIPTION
The OpenSRS docs state that `transfer_id` will be present in the response attributes of domain registration requests with `reg_type=transfer`. http://domains.opensrs.guide/v1.0/docs/sw_register-domain#section-response-parameters-for-sw_register-domain

`transfer_id` was previously being fetched from the `process_pending` request (that is not documented).
Now that domain transfer requests can be processed immediately, the `transfer_id` needs to be returned as part of the response from the original transfer request so it can be used in additional requests related to the domain transfer.

I think the version bump for this should be to 3.0.1 since it is more of a bug fix than additional functionality.