### PR TITLE
bump version for missing transfer_id value bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
-## Dev
+## 3.0.1
 * Return `transfer_id` from `transfer_domain` and
     `create_pending_domain_transfer`
 

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS


### PR DESCRIPTION
`transfer_id` should have been returned by `transfer_domain` and `create_pending_domain_transfer` in 3.0.0