### PR TITLE
fix transfer_id KeyError for pending domain transfer requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## Dev
+* Fix `transfer_id` KeyError on pending domain transfer orders
+
 ## 3.0.1
 * Return `transfer_id` from `transfer_domain` and
     `create_pending_domain_transfer`

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -351,7 +351,7 @@ class OpenSRS(object):
         rsp = self._sw_register_domain(attrs)
         response_attributes = rsp.get_data()['attributes']
         order_id = response_attributes['id']
-        transfer_id = response_attributes['transfer_id']
+        transfer_id = response_attributes.get('transfer_id')
         return {
             'domain_name': domain,
             'registrar_data': {

--- a/tests/test_opensrsapi.py
+++ b/tests/test_opensrsapi.py
@@ -605,13 +605,13 @@ class OpenSRSTest(TestCase):
         opensrs = self.safe_opensrs(
             self._get_domain_transfer_request_data('foo.com', 'foo', 'bar'),
             self._get_domain_transfer_response_data(
-                attributes={'id': '123', 'transfer_id': '456'})
+                attributes={'id': '123'})
         )
         expected = {
             'domain_name': 'foo.com',
             'registrar_data': {
                 'ref_number': '123',
-                'transfer_id': '456'
+                'transfer_id': None,
             }
         }
         self.assertEqual(


### PR DESCRIPTION
Fixes https://sentry.io/yola/domainservice/issues/250302723/events/5249450207/

Transfer domain orders only include the `transfer_id` key when handle=='process'.
Pending domain transfer orders have handle set to 'save'.

This was tested on serv3 in the shell with the commands below:

```python
from django.conf import settings
import opensrs

from domains.models import User, Registrar

user = User.objects.get(email='stefano@yola.com')
registrar = Registrar.objects.get(id='opensrs')
registrar_data = user.get_registrar_data(registrar).registrar_data
password = registrar_data['password']
user_id = registrar_data['user_id']
nameservers = [u'candy.ns.cloudflare.com', u'major.ns.cloudflare.com']

host = settings.OPENSRS_HOST
port = settings.OPENSRS_PORT
username = settings.OPENSRS_USER
private_key = settings.OPENSRS_PRIVATE_KEY
default_timeout = settings.OPENSRS_DEFAULT_TIMEOUT

osrs = opensrs.OpenSRS(host, port, username, private_key, default_timeout)


attrs = osrs._make_domain_transfer_attrs(
	domain, user, , password, nameservers,
	None, order_processing_method='save')

rsp = osrs._sw_register_domain(attrs)
response_attributes = rsp.get_data()['attributes']
```

When `order_processing_method` (which gets passed on as `handle` was `save` the response was:
`{'admin_email': 'stefano@yola.com', 'id': '214569908'}`

When `order_processing_method` was `process` the response was:
`{'transfer_id': '11318049', 'registration_text': 'Transfer request has been successfully sent to admin contact', 'admin_email': 'stefano@yola.com', 'registration_code': '200', 'id': '214569938'}`

The opensrs was not clear about that.  Testing domain transfers in their sandbox doesn't seem to work since it returned `487: Domain not transferable.\\nDomain not registered` for all the domains I tried.
