### PR TITLE
Add method to disable Parked Pages Service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## 4.1.0
+* Add `OpenSRS.disable_parked_pages_service()`.
+
 ## 4.0.0
 * Add Python 3 support
 * Add `OpenSRS.simple_transfer()` and `OpenSRS.get_simple_transfer_status()`

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '4.0.0'
+__version__ = '4.1.0'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -779,3 +779,13 @@ class OpenSRS(object):
             action='MODIFY', object='DOMAIN', attributes=attributes,
             cookie=cookie
         )
+
+    def disable_parked_pages_service(self, cookie, domain_name):
+        attributes = {
+            'data': 'parkpage_state',
+            'domain': domain_name,
+            'state': 'off'
+        }
+
+        self._req(action='MODIFY', object='DOMAIN', attributes=attributes,
+                  cookie=cookie)


### PR DESCRIPTION
OpenSRS enables Parked Pages Service by default if no nameservers provided during initial registration (that's our usual setup atm).  And we need a way to disable that program.

In the scope of https://github.com/yola/production/issues/6031