### PR TITLE
Allow to specify 'services' to 'OpenSRS.suggest_domains()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
-## 4.1.1
+## 4.2.0
 * Allow to specify `services` to `OpenSRS.suggest_domains()`.
 
 ## 4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## 4.1.1
+* Allow to specify `services` to `OpenSRS.suggest_domains()`.
+
 ## 4.1.0
 * Add `OpenSRS.disable_parked_pages_service()`.
 

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '4.1.0'
+__version__ = '4.1.1'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '4.1.1'
+__version__ = '4.2.0'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -237,12 +237,12 @@ class OpenSRS(object):
         return self._req(action='ADVANCED_UPDATE_NAMESERVERS', object='DOMAIN',
                          cookie=cookie, attributes=attributes)
 
-    def _name_suggest_domain(self, search_string, tlds, maximum=None,
+    def _name_suggest_domain(self, search_string, tlds, services, maximum=None,
                              max_wait_time=None, search_key=None):
         attributes = {
             'searchstring': search_string,
             'tlds': tlds,
-            'services': ['lookup', 'suggestion'],
+            'services': services,
         }
         if max_wait_time is not None:
             attributes['max_wait_time'] = str(max_wait_time)
@@ -467,12 +467,14 @@ class OpenSRS(object):
         return (attribs['transferrable'] == '1', attribs.get('reason', None))
 
     def suggest_domains(self, search_string, tlds, maximum=None,
-                        max_wait_time=None, search_key=None):
-        rsp = self._name_suggest_domain(search_string, tlds, maximum,
+                        max_wait_time=None, search_key=None, services=None):
+        if services is None:
+            services = ['lookup', 'suggestion']
+        rsp = self._name_suggest_domain(search_string, tlds, services, maximum,
                                         max_wait_time, search_key)
         data = rsp.get_data()
         domains = {}
-        for k in ['lookup', 'suggestion']:
+        for k in services:
             domrsp = data['attributes'].get(k, None)
             domains[k] = []
             if domrsp is None:


### PR DESCRIPTION
part of https://github.com/yola/domainservice/issues/687


We want to specify only `lookup` service, so potentially opensrs  responds faster