### PR TITLE
Add get_balance method

### DIFF
--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -794,7 +794,9 @@ class OpenSRS(object):
                   cookie=cookie)
 
     def get_balance(self):
-        attributes = self._req(action='GET_BALANCE', object='BALANCE', attributes=None).get_data()['attributes']
+        attributes = self._req(
+            action='GET_BALANCE', object='BALANCE', attributes=None
+        ).get_data()['attributes']
 
         balance = decimal.Decimal(attributes['balance'])
         hold_balance = decimal.Decimal(attributes['hold_balance'])

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -1,5 +1,6 @@
 from functools import update_wrapper
 import logging
+import decimal
 
 from demands.pagination import PaginatedResults, RESULTS_KEY
 
@@ -791,3 +792,18 @@ class OpenSRS(object):
 
         self._req(action='MODIFY', object='DOMAIN', attributes=attributes,
                   cookie=cookie)
+
+    def get_balance(self):
+        attributes = self._req(action='GET_BALANCE', object='BALANCE', attributes=None).get_data()['attributes']
+
+        balance = decimal.Decimal(attributes['balance'])
+        hold_balance = decimal.Decimal(attributes['hold_balance'])
+        available_balance = balance - hold_balance
+        if available_balance < 0:
+            available_balance = 0
+
+        return {
+            'balance': balance,
+            'hold_balance': hold_balance,
+            'available_balance': available_balance
+        }

--- a/opensrs/xcp.py
+++ b/opensrs/xcp.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import decimal
 try:
     from urllib.request import urlopen, Request
 except ImportError:
@@ -112,8 +113,10 @@ class XCPMessage(object):
             'protocol': 'XCP',
             'action': action,
             'object': object,
-            'attributes': attributes,
         }
+        if attributes is not None:
+            data['attributes'] = attributes
+
         data.update(kw)
 
         self.ops_message = OPSMessage(data=data)

--- a/opensrs/xcp.py
+++ b/opensrs/xcp.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import decimal
 try:
     from urllib.request import urlopen, Request
 except ImportError:


### PR DESCRIPTION
* OpenSRS closes the connection if you specify attributes on GET_BALANCE BALANCE (http.client.RemoteDisconnected: Remote end closed connection without response) so I needed to make it optional in XCPMessage
* I put the balances into Decimals so users don't accidentally cast them to floats
* I added available_balance as this would probably be the most common need for this method, but you can remove this if preferred
