### PR TITLE
Make ElementTree work with Python 3.9+

### DIFF
--- a/opensrs/xcp.py
+++ b/opensrs/xcp.py
@@ -87,18 +87,29 @@ class OPSMessage(object):
         if not ET.iselement(base_node):
             return base_node
         if base_node.tag == 'item':
-            if base_node.getchildren() == []:
-                return base_node.text
+            try:
+                if base_node.getchildren() == []:
+                    return base_node.text
+            except:
+                if list(base_node) == []:
+                    return base_node.text
             return self.get_data(base_node[0])
         if base_node.tag == 'dt_array':
-            indexed_children = [(e.get('key'), e) for e in
-                                base_node.getchildren()]
+            try:
+                indexed_children = [(e.get('key'), e) for e in
+                                    base_node.getchildren()]
+            except:
+                indexed_children = [(e.get('key'), e) for e in base_node]
             indexed_children.sort()
             return [self.get_data(e) for i, e in indexed_children]
         if base_node.tag == 'dt_assoc':
             data = {}
-            for e in base_node.getchildren():
-                data[e.get('key')] = self.get_data(e)
+            try:
+                for e in base_node.getchildren():
+                    data[e.get('key')] = self.get_data(e)
+            except:
+                for e in base_node:
+                    data[e.get('key')] = self.get_data(e)
             return data
         if base_node.tag == 'dt_scalar':
             return base_node.text

--- a/opensrs/xcp.py
+++ b/opensrs/xcp.py
@@ -87,29 +87,17 @@ class OPSMessage(object):
         if not ET.iselement(base_node):
             return base_node
         if base_node.tag == 'item':
-            try:
-                if base_node.getchildren() == []:
-                    return base_node.text
-            except:
-                if list(base_node) == []:
-                    return base_node.text
+            if list(base_node) == []:
+                return base_node.text
             return self.get_data(base_node[0])
         if base_node.tag == 'dt_array':
-            try:
-                indexed_children = [(e.get('key'), e) for e in
-                                    base_node.getchildren()]
-            except:
-                indexed_children = [(e.get('key'), e) for e in base_node]
+            indexed_children = [(e.get('key'), e) for e in base_node]
             indexed_children.sort()
             return [self.get_data(e) for i, e in indexed_children]
         if base_node.tag == 'dt_assoc':
             data = {}
-            try:
-                for e in base_node.getchildren():
-                    data[e.get('key')] = self.get_data(e)
-            except:
-                for e in base_node:
-                    data[e.get('key')] = self.get_data(e)
+            for e in base_node:
+                data[e.get('key')] = self.get_data(e)
             return data
         if base_node.tag == 'dt_scalar':
             return base_node.text


### PR DESCRIPTION
Per the python documentation, getchildren() has been deprecated since Python versions
3.2 and 2.7:
https://docs.python.org/3.8/library/xml.etree.elementtree.html
