### PR TITLE
Fix using non ascii symbols for "org_name" generated from user name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
 ## 4.3.2
-* Fix using non ascii symbols for "org_name" generated from user name.
+* Fix using non-ascii symbols for "org_name" generated from user's name.
 
 ## 4.3.1
 * Allow blank 'orgname' param.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Changelog](https://github.com/yola/opensrs/releases)
 
+## 4.3.2
+* Fix using non ascii symbols for "org_name" generated from user name.
+
 ## 4.3.1
 * Allow blank 'orgname' param.
 

--- a/opensrs/__init__.py
+++ b/opensrs/__init__.py
@@ -2,7 +2,7 @@
 # namespacing cleaner.
 
 __doc__ = 'Client library for OpenSRS'
-__version__ = '4.3.1'
+__version__ = '4.3.2'
 __url__ = 'https://github.com/yola/opensrs'
 
 from opensrs.opensrsapi import OpenSRS

--- a/opensrs/opensrsapi.py
+++ b/opensrs/opensrsapi.py
@@ -137,7 +137,7 @@ class OpenSRS(object):
 
     def make_contact(self, user, domain, **kw):
         org_name = kw.get(
-            'orgname', '{} {}'.format(user.first_name, user.last_name))
+            'orgname', u'{} {}'.format(user.first_name, user.last_name))
         return {
             'first_name': user.first_name,
             'last_name': user.last_name,


### PR DESCRIPTION
related to https://yola.sentry.io/issues/4016462607/

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 3: ordinal not in range(128)
  File "django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "domains/views/domains.py", line 338, in update_contacts
    reg.update_domain_contacts(dom.user, domain_name)
  File "registrar/registrar.py", line 749, in update_domain_contacts
    return registrar.update_domain_contacts(domain_name)
  File "registrar/osrs.py", line 55, in wrapper
    return f(*args, **kw)
  File "registrar/osrs.py", line 488, in update_domain_contacts
    return self._update_domain_contacts(domain_name)
  File "registrar/osrs.py", line 78, in wrapped
    rsp = f(self, domain_name, *args, **kw)
  File "registrar/osrs.py", line 484, in _update_domain_contacts
    return self.get_opensrs().set_contacts(self._get_cookie(domain_name), self.user, domain_name)
  File "opensrs/opensrsapi.py", line 644, in set_contacts
    self._set_domain_contacts(cookie, user, domain)
  File "opensrs/opensrsapi.py", line 390, in _set_domain_contacts
    contact = self.make_contact(user, domain)
  File "opensrs/opensrsapi.py", line 140, in make_contact
    'orgname', '{} {}'.format(user.first_name, user.last_name))
```